### PR TITLE
fixed a liitle bit function _checkConvert

### DIFF
--- a/jquery.autoKana.js
+++ b/jquery.autoKana.js
@@ -79,7 +79,9 @@
                     }
                 } else {
                     if (values.length == input.length && values.join('') != input) {
-                        _stateConvert();
+                        if (input.match(kana_extraction_pattern)) {
+                            _stateConvert();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
bug :
don't convert to katakana when input VOICED(SEMI-VOICED) SOUND MARK or make character compact with software keyboard

スマホのキーボードで濁点や半濁点をつけたり、文字を小さくしたりしたときにカタカナに変換されないようだったので直してみたよ。
マージしてくれるとうれしい。