### PR TITLE
Fix some global variables to inside-function scope

### DIFF
--- a/jquery.autoKana.js
+++ b/jquery.autoKana.js
@@ -2,7 +2,7 @@
 //
 // Based on the AutoRuby library created by:
 // Copyright (c) 2005-2008 spinelz.org (http://script.spinelz.org/)
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
 // "Software"), to deal in the Software without restriction, including
@@ -10,7 +10,7 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
 //
@@ -37,7 +37,10 @@
             active = false,
             timer = null,
             flagConvert = true,
-            input;
+            input,
+            values,
+            ignoreString,
+            baseKana;
 
         elName = $(element1);
         elKana = $(element2);


### PR DESCRIPTION
Sometime some input element value would be changed accidently due to refer global variables, when multiple input elements which associated with `autokana` are exists.