### PR TITLE
fixed a many time calling function in _checkValue

### DIFF
--- a/jquery.autoKana.js
+++ b/jquery.autoKana.js
@@ -93,7 +93,7 @@
         function _checkValue() {
             var new_input, new_values;
             new_input = elName.val()
-            if (new_input == '') {
+            if (new_input == '' && elKana.val() != '') {
                 _stateClear();
                 _setKana();
             } else {


### PR DESCRIPTION
Hi, I'm ken.
ref #9

Now, if focus input value is empty, calling _setKana() at Interval 30ms.
I think that it call timing is change input value.

I add if condition `elKana.val() != ''`

### calling _setKana() at Interval 30ms ver.
https://codepen.io/aokiken/full/YBZGjX

### fixed ver.
https://codepen.io/aokiken/full/xMqqJe

Thanks for Reading :)